### PR TITLE
FIX: game-service plugin had a wrong route to fetch game stats for given user

### DIFF
--- a/backend/user-service/src/plugins/gameServiceClient.ts
+++ b/backend/user-service/src/plugins/gameServiceClient.ts
@@ -57,7 +57,7 @@ const buildClient = ({ baseUrl, timeout }: GameServiceClientConfig): GameService
 	
 	const getGamestats = async (request: GamestatsRequest): Promise<GamestatsView> => {
 		const { user } = request.Params;
-		const path = `internal/gamestats/${user}`;
+		const path = `/internal/gamestats/${user}`;
 		const res = await call<GamestatsResponse>('GET', path, undefined, [200]);
 		return {userID: res.user, wins: res.wins, losses: res.losses};
 	}
@@ -76,7 +76,7 @@ declare module 'fastify' {
 }
 
 const gameServiceClientPlugin: FastifyPluginAsync = async (app : FastifyInstance) => {
-	const baseUrl = process.env.GAME_SERVICE_URL ?? 'http://game-service:5004';
+	const baseUrl = process.env.GAME_SERVICE_URL ?? 'http://game-service:5001';
 	
 	app.decorate('gameService', buildClient({ baseUrl, timeout: 3000}));
 };


### PR DESCRIPTION
This pull request makes two changes to the `gameServiceClient.ts` file in the `backend/user-service` module to fix path and port configuration issues for the Game Service client.

Configuration fixes:

* [`backend/user-service/src/plugins/gameServiceClient.ts`](diffhunk://#diff-f45ae87172d72d60a688d94cb32133c7dcd9060eaa91582833afc67411e68104L60-R60): Corrected the path in the `getGamestats` function by adding a leading slash to ensure proper routing (`/internal/gamestats/${user}` instead of `internal/gamestats/${user}`).
* [`backend/user-service/src/plugins/gameServiceClient.ts`](diffhunk://#diff-f45ae87172d72d60a688d94cb32133c7dcd9060eaa91582833afc67411e68104L79-R79): Updated the default port for the `GAME_SERVICE_URL` environment variable from `5004` to `5001` to align with the correct service configuration